### PR TITLE
Fix missing deltarpm when init Vagrant

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -32,6 +32,8 @@ Vagrant.configure(2) do |config|
 
   config.vm.provision "shell", inline: <<-EOC
 
+yum install -y deltarpm
+
 yum -y update
 
 yum -y install git


### PR DESCRIPTION
@kenji4569 

When init Vagrant, I got this notice.

```
==> default: Delta RPMs disabled because /usr/bin/applydeltarpm not installed.
```

It's better to destroy old instance of Vagrant by `vagrant destroy` and re-initialize it `vagrant up`.
